### PR TITLE
#2 example of how to add a new trigger type.

### DIFF
--- a/SwissArmyKnifeForMugen/Displays/DebugForm.cs
+++ b/SwissArmyKnifeForMugen/Displays/DebugForm.cs
@@ -820,7 +820,7 @@ namespace SwissArmyKnifeForMugen.Displays
             this.valueComboBox.MouseClick += new MouseEventHandler(this.valueComboBox_MouseClick);
             this.triggerComboBox.FormattingEnabled = true;
             // list of available trigger types
-            this.triggerComboBox.Items.AddRange(new object[7]
+            this.triggerComboBox.Items.AddRange(new object[]
             {
         (object) "Alive",
         (object) "FVar( xxx )",
@@ -828,7 +828,8 @@ namespace SwissArmyKnifeForMugen.Displays
         (object) "SysFVar( xxx )",
         (object) "SysVar( xxx )",
         (object) "Var( xxx )",
-        (object) "NumHelper"
+        (object) "NumHelper",
+        (object) "NumHelper( xxx )"
             });
             this.triggerComboBox.Location = new Point(58, 44);
             this.triggerComboBox.Name = "triggerComboBox";
@@ -2636,6 +2637,12 @@ namespace SwissArmyKnifeForMugen.Displays
                     {
                         trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_FVAR;
                         trigger.index = result5;
+                    }
+                    int result6;
+                    if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE && int.TryParse(Regex.Replace(input, "numhelper\\(\\s*([0-9]+)\\s*\\)", "$1"), out result6) && (result6 >= 0 && result6 <= Int32.MaxValue))
+                    {
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMHELPER_ID;
+                        trigger.index = result6;
                     }
                 }
                 if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE)

--- a/SwissArmyKnifeForMugen/MugenWindow.cs
+++ b/SwissArmyKnifeForMugen/MugenWindow.cs
@@ -2746,9 +2746,9 @@ namespace SwissArmyKnifeForMugen
         /// <br/>all custom monitors use <c>GAMETIME_BASE_OFFSET</c> as their offset so it breaks every frame.
         /// </summary>
         /// <param name="baseAddr">mugen base address</param>
-        /// <param name="rootAddr">root address for the target of this trigger</param>
+        /// <param name="targetAddr">address for the target of this trigger</param>
         /// <returns></returns>
-        private TriggerValue_t GetTriggerValueEx(uint baseAddr, uint rootAddr)
+        private TriggerValue_t GetTriggerValueEx(uint baseAddr, uint targetAddr)
         {
             // we don't have error checking here bc this only gets called from GetTriggerValue
             // if this becomes more extensible, add error checking
@@ -2756,14 +2756,20 @@ namespace SwissArmyKnifeForMugen
             // build the value
             TriggerDatabase.TriggerValue_t triggerValueT = new TriggerDatabase.TriggerValue_t();
             // do logic based on type
+            int playerID = this.GetPlayerId(targetAddr);
             switch (targetTrigger.triggerType)
             {
                 case TriggerId.TRIGGER_NUMHELPER:
                     // count the number of helpers owned by the selected root
-                    int playerID = this.GetPlayerId(rootAddr);
                     int numHelper = this.GetNumHelper(baseAddr, playerID);
                     triggerValueT.valueType = TriggerDatabase.ValueType.VALUE_INT;
                     triggerValueT.SetInt32Value(numHelper);
+                    break;
+                case TriggerId.TRIGGER_NUMHELPER_ID:
+                    // count the number of helpers owned by the selected root, with a specified ID
+                    int numHelperID = this.GetNumHelperID(baseAddr, playerID, targetTrigger.index);
+                    triggerValueT.valueType = TriggerDatabase.ValueType.VALUE_INT;
+                    triggerValueT.SetInt32Value(numHelperID);
                     break;
                 default:
                     return (TriggerDatabase.TriggerValue_t)null;
@@ -2779,6 +2785,26 @@ namespace SwissArmyKnifeForMugen
             {
                 uint playerAddr = this._GetPlayerAddr(baseAddr, (uint)((ulong)this._addr_db.PLAYER_1_BASE_OFFSET + (ulong)(index * 4)));
                 if (playerAddr != 0U && this.DoesExist(playerAddr) && playerID == this.GetRootId(baseAddr, this.GetPlayerId(playerAddr)))
+                    num++;
+            }
+            return num;
+        }
+
+        /// <summary>
+        /// helper function to get the number of Helpers with a given ID owned by a given player
+        /// </summary>
+        /// <param name="baseAddr"></param>
+        /// <param name="playerID"></param>
+        /// <param name="helperID"></param>
+        /// <returns></returns>
+        private int GetNumHelperID(uint baseAddr, int playerID, int helperID)
+        {
+            // iterate 56 helpers
+            int num = 0;
+            for (int index = 4; index < 60; ++index)
+            {
+                uint playerAddr = this._GetPlayerAddr(baseAddr, (uint)((ulong)this._addr_db.PLAYER_1_BASE_OFFSET + (ulong)(index * 4)));
+                if (playerAddr != 0U && this.DoesExist(playerAddr) && playerID == this.GetRootId(baseAddr, this.GetPlayerId(playerAddr)) && helperID == this.GetHelperId(playerAddr))
                     num++;
             }
             return num;

--- a/SwissArmyKnifeForMugen/Triggers/TriggerDatabase.cs
+++ b/SwissArmyKnifeForMugen/Triggers/TriggerDatabase.cs
@@ -41,6 +41,7 @@ namespace SwissArmyKnifeForMugen.Triggers
                 case TriggerId.TRIGGER_FVAR:
                     return mugen.FVAR_PLAYER_OFFSET;
                 case TriggerId.TRIGGER_NUMHELPER:
+                case TriggerId.TRIGGER_NUMHELPER_ID:
                     isOffsetFromBase = true;
                     return mugen.GAMETIME_BASE_OFFSET;
                 default:
@@ -71,6 +72,8 @@ namespace SwissArmyKnifeForMugen.Triggers
                     return ValueType.VALUE_FLOAT;
                 case TriggerId.TRIGGER_NUMHELPER:
                     return ValueType.VALUE_INT;
+                case TriggerId.TRIGGER_NUMHELPER_ID:
+                    return ValueType.VALUE_INT;
                 default:
                     return ValueType.VALUE_NONE;
             }
@@ -89,6 +92,7 @@ namespace SwissArmyKnifeForMugen.Triggers
             TRIGGER_VAR,
             TRIGGER_FVAR,
 			TRIGGER_NUMHELPER,
+            TRIGGER_NUMHELPER_ID,
         }
 
         /// <summary>


### PR DESCRIPTION
meant to be a fairly straightforward 'walkthrough' of how to implement a new trigger type.

of course, not every trigger will need regex in `setButton_Click_Handler`, a case in `GetTriggerValueEx`, or a helper function like `GetNumHelperID`.