### PR TITLE
#2 implemented several new trigger types

### DIFF
--- a/SwissArmyKnifeForMugen/Displays/DebugForm.cs
+++ b/SwissArmyKnifeForMugen/Displays/DebugForm.cs
@@ -829,7 +829,12 @@ namespace SwissArmyKnifeForMugen.Displays
         (object) "SysVar( xxx )",
         (object) "Var( xxx )",
         (object) "NumHelper",
-        (object) "NumHelper( xxx )"
+        (object) "NumHelper( xxx )",
+        (object) "NumProjId( xxx )",
+        (object) "NumExplod( xxx )",
+        (object) "NumTarget",
+        (object) "HasTargetWithID( xxx )",
+        (object) "GetHitVar(damage)",
             });
             this.triggerComboBox.Location = new Point(58, 44);
             this.triggerComboBox.Name = "triggerComboBox";
@@ -2614,6 +2619,10 @@ namespace SwissArmyKnifeForMugen.Displays
                         trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_STATENO;
                     else if (input == "numhelper")
                         trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMHELPER;
+                    else if (input == "numtarget")
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMTARGET;
+                    else if (input == "gethitvar(damage)")
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_DAMAGE;
                     int result2;
                     if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE && int.TryParse(Regex.Replace(input, "sysvar\\(\\s*([0-9]+)\\s*\\)", "$1"), out result2) && (result2 >= 0 && result2 <= 4))
                     {
@@ -2643,6 +2652,24 @@ namespace SwissArmyKnifeForMugen.Displays
                     {
                         trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMHELPER_ID;
                         trigger.index = result6;
+                    }
+                    int result7;
+                    if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE && int.TryParse(Regex.Replace(input, "numprojid\\(\\s*([0-9]+)\\s*\\)", "$1"), out result7) && (result7 >= 0 && result7 <= Int32.MaxValue))
+                    {
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMPROJ_ID;
+                        trigger.index = result7;
+                    }
+                    int result8;
+                    if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE && int.TryParse(Regex.Replace(input, "numexplod\\(\\s*([0-9]+)\\s*\\)", "$1"), out result8) && (result8 >= 0 && result8 <= Int32.MaxValue))
+                    {
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_NUMEXPLOD_ID;
+                        trigger.index = result8;
+                    }
+                    int result9;
+                    if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE && int.TryParse(Regex.Replace(input, "hastargetwithid\\(\\s*([0-9]+)\\s*\\)", "$1"), out result9) && (result9 >= 0 && result9 <= Int32.MaxValue))
+                    {
+                        trigger.triggerType = TriggerDatabase.TriggerId.TRIGGER_HASTARGET;
+                        trigger.index = result9;
                     }
                 }
                 if (trigger.triggerType == TriggerDatabase.TriggerId.TRIGGER_NONE)
@@ -2681,6 +2708,17 @@ namespace SwissArmyKnifeForMugen.Displays
                                     triggerValueT1.SetInt32Value(result);
                                 }
                             }
+                            else if (TriggerDatabase.GetTriggerValueType(triggerType) == TriggerDatabase.ValueType.VALUE_BOOL)
+                            {
+                                bool result;
+                                s = Regex.Replace(input, "\\=\\s*(true|false)", "$1");
+                                if (bool.TryParse(s, out result))
+                                {
+                                    target.SetTargetValueOpType(TriggerCheckTarget.ValueOpType.VALUE_OP_EQ);
+                                    triggerValueT1.valueType = TriggerDatabase.ValueType.VALUE_BOOL;
+                                    triggerValueT1.SetBoolValue(result);
+                                }
+                            }
                             else
                             {
                                 float result;
@@ -2703,6 +2741,17 @@ namespace SwissArmyKnifeForMugen.Displays
                                     target.SetTargetValueOpType(TriggerCheckTarget.ValueOpType.VALUE_OP_NOT_EQ);
                                     triggerValueT1.valueType = TriggerDatabase.ValueType.VALUE_INT;
                                     triggerValueT1.SetInt32Value(result);
+                                }
+                            }
+                            else if (TriggerDatabase.GetTriggerValueType(triggerType) == TriggerDatabase.ValueType.VALUE_BOOL)
+                            {
+                                bool result;
+                                s = Regex.Replace(input, "\\!\\=\\s*(true|false)", "$1");
+                                if (bool.TryParse(s, out result))
+                                {
+                                    target.SetTargetValueOpType(TriggerCheckTarget.ValueOpType.VALUE_OP_NOT_EQ);
+                                    triggerValueT1.valueType = TriggerDatabase.ValueType.VALUE_BOOL;
+                                    triggerValueT1.SetBoolValue(result);
                                 }
                             }
                             else

--- a/SwissArmyKnifeForMugen/Triggers/TriggerDatabase.cs
+++ b/SwissArmyKnifeForMugen/Triggers/TriggerDatabase.cs
@@ -40,8 +40,14 @@ namespace SwissArmyKnifeForMugen.Triggers
                     return mugen.VAR_PLAYER_OFFSET;
                 case TriggerId.TRIGGER_FVAR:
                     return mugen.FVAR_PLAYER_OFFSET;
+                case TriggerId.TRIGGER_DAMAGE:
+                    return mugen.DAMAGE_PLAYER_OFFSET;
                 case TriggerId.TRIGGER_NUMHELPER:
                 case TriggerId.TRIGGER_NUMHELPER_ID:
+                case TriggerId.TRIGGER_NUMPROJ_ID:
+                case TriggerId.TRIGGER_NUMEXPLOD_ID:
+                case TriggerId.TRIGGER_NUMTARGET:
+                case TriggerId.TRIGGER_HASTARGET:
                     isOffsetFromBase = true;
                     return mugen.GAMETIME_BASE_OFFSET;
                 default:
@@ -74,6 +80,16 @@ namespace SwissArmyKnifeForMugen.Triggers
                     return ValueType.VALUE_INT;
                 case TriggerId.TRIGGER_NUMHELPER_ID:
                     return ValueType.VALUE_INT;
+                case TriggerId.TRIGGER_NUMPROJ_ID:
+                    return ValueType.VALUE_INT;
+                case TriggerId.TRIGGER_NUMEXPLOD_ID:
+                    return ValueType.VALUE_INT;
+                case TriggerId.TRIGGER_NUMTARGET:
+                    return ValueType.VALUE_INT;
+                case TriggerId.TRIGGER_HASTARGET:
+                    return ValueType.VALUE_BOOL;
+                case TriggerId.TRIGGER_DAMAGE:
+                    return ValueType.VALUE_INT;
                 default:
                     return ValueType.VALUE_NONE;
             }
@@ -93,6 +109,11 @@ namespace SwissArmyKnifeForMugen.Triggers
             TRIGGER_FVAR,
 			TRIGGER_NUMHELPER,
             TRIGGER_NUMHELPER_ID,
+            TRIGGER_NUMPROJ_ID,
+            TRIGGER_NUMEXPLOD_ID,
+            TRIGGER_NUMTARGET,
+            TRIGGER_HASTARGET,
+            TRIGGER_DAMAGE,
         }
 
         /// <summary>
@@ -104,6 +125,7 @@ namespace SwissArmyKnifeForMugen.Triggers
             VALUE_ANY,
             VALUE_INT,
             VALUE_FLOAT,
+            VALUE_BOOL,
         }
 
         /// <summary>
@@ -115,12 +137,14 @@ namespace SwissArmyKnifeForMugen.Triggers
             public uint mask;
             private int iValue;
             private float fValue;
+            private bool bValue;
 
             public TriggerValue_t()
             {
                 valueType = ValueType.VALUE_NONE;
                 iValue = 0;
                 fValue = 0.0f;
+                bValue = false;
                 mask = uint.MaxValue;
             }
 
@@ -129,6 +153,7 @@ namespace SwissArmyKnifeForMugen.Triggers
                 valueType = ValueType.VALUE_NONE;
                 iValue = 0;
                 fValue = 0.0f;
+                bValue = false;
                 mask = uint.MaxValue;
             }
 
@@ -138,9 +163,13 @@ namespace SwissArmyKnifeForMugen.Triggers
 
             public float GetSingleValue() => fValue;
 
+            public bool GetBoolValue() => bValue;
+
             public void SetInt32Value(int value) => iValue = value;
 
             public void SetSingleValue(float value) => fValue = value;
+
+            public void SetBoolValue(bool value) => bValue = value;
 
             public bool isEqual(TriggerValue_t value)
             {
@@ -156,6 +185,8 @@ namespace SwissArmyKnifeForMugen.Triggers
                         return iValue == value.iValue;
                     case ValueType.VALUE_FLOAT:
                         return fValue == (double)value.fValue;
+                    case ValueType.VALUE_BOOL:
+                        return bValue == value.bValue;
                     default:
                         return false;
                 }


### PR DESCRIPTION
this PR resolves #2 

adding several new triggers, in this pr the following are added:

NumHelper( xxx )
NumProjId( xxx )
NumExplod( xxx )
NumTarget
HasTargetWithID( xxx )
GetHitVar(damage)

of these, NumHelper/NumProjId resolve up to the root PlayerID when checking, while NumExplod/NumTarget/HasTargetWithID resolve to the indicated PlayerID. (GetHitVar(damage) uses the non-custom system and so resolves to the indicated PlayerID as expected).

also added a new ValueType, VALUE_BOOL, for HasTargetWithID. it supports only VALUE_OP_EQ and VALUE_OP_NOT_EQ and is used for HasTargetWithID. this ValueType accepts (true|false) as its value.