### PR TITLE
#6 add debug colors for all mugenversion

### DIFF
--- a/SwissArmyKnifeForMugen/Databases/Mugen10DB.cs
+++ b/SwissArmyKnifeForMugen/Databases/Mugen10DB.cs
@@ -13,6 +13,10 @@ namespace SwissArmyKnifeForMugen.Databases
     {
         public Mugen10DB()
         {
+            USE_NEW_DEBUG_COLOR_ADDR = true;
+            NEW_DEBUG_COLOR_OFFSETS = new uint[] { 0x44F011, 0x44F189, 0x44F2A3, 0x44F3AD, 0x44EF8B };
+            NEW_DEBUG_COLOR_SN_OFFSETS = new uint[] {  };
+
             MUGEN_POINTER_BASE_OFFSET = 0x52B40C;
             PAUSE_ADDR = 0x52B950;
             CMD_CURRENT_INDEX_ADDR = 0x52A9E8;

--- a/SwissArmyKnifeForMugen/Databases/Mugen11B1DB.cs
+++ b/SwissArmyKnifeForMugen/Databases/Mugen11B1DB.cs
@@ -14,8 +14,9 @@ namespace SwissArmyKnifeForMugen.Databases
     {
         public Mugen11B1DB()
         {
-            // TODO: enable this after finding the right code addrs.
-            USE_NEW_DEBUG_COLOR_ADDR = false;
+            USE_NEW_DEBUG_COLOR_ADDR = true;
+            NEW_DEBUG_COLOR_OFFSETS = new uint[] { 0x419678, 0x4196E2, 0x419910, 0x419815 };
+            NEW_DEBUG_COLOR_SN_OFFSETS = new uint[] { 0x4199F8, 0x419A04, 0x419A09 };
 
             SPEED_MODE_BASE_OFFSET = 78064U;
             OFFSET_EXPLOD_LIST_OFFSET = 624U;

--- a/SwissArmyKnifeForMugen/MugenWindow.cs
+++ b/SwissArmyKnifeForMugen/MugenWindow.cs
@@ -2029,7 +2029,8 @@ namespace SwissArmyKnifeForMugen
                 this.ApplyDebugColorInt(baseAddr, colorBase, debugColor);
             }
             // stateno is split up, so apply differently
-            this.ApplyDebugColorSplit(baseAddr, this._addr_db.NEW_DEBUG_COLOR_SN_OFFSETS, debugColor);
+            if (this._addr_db.NEW_DEBUG_COLOR_SN_OFFSETS.Length == 3)
+                this.ApplyDebugColorSplit(baseAddr, this._addr_db.NEW_DEBUG_COLOR_SN_OFFSETS, debugColor);
         }
 
         /// <summary>


### PR DESCRIPTION
resolves #6 

just a matter of finding the right instructions to patch.

added a safety check for NEW_DEBUG_COLOR_SN_OFFSETS since Mugen 1.0 doesn't need this.